### PR TITLE
Added dependency python-gobject to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ If you are using Debian GNU/Linux:
 sudo apt install efibootmgr python3
 ```
 
+Not all distros install **pyhton-gobject** automatically with Python3, but it is required to run this script.
+
+For Arch users:
+
+```
+sudo pacman -S efibootmgr python3 python-gobject
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
Failed to start on Arch, the dependency on python-gobject was non-trivial to find out, so I added it to README